### PR TITLE
adjustments on read.me and gitlab. 

### DIFF
--- a/satori_help/docs/README.md
+++ b/satori_help/docs/README.md
@@ -31,13 +31,13 @@ We provide a comprehensive approach to testing code repositories on Github. Whet
 
 ## [Monitor](modes/monitor.md)
 
-Your playbooks can run at a certain rate. The frequency is defined within the settings with a certain rate (ie, '5 minutes') or using the cron format (ie, '*/5 * * * *'). 
-
-You can view your monitors using the [Web interface](https://www.satori.ci/monitors/), the CLI (`satori monitors`), or [Grafana](https://github.com/satorici/satori-plugin-grafana).
+Monitors allow you to automate scheduled checks on systems, ensuring they function correctly over time. 
+You can set your playbooks to run at regular intervals, defined by a time rate (e.g., '5 minutes')
+Monitors can be viewed via the [Web interface](https://www.satori.ci/monitors/), the CLI (`satori monitors`), or [Grafana](https://github.com/satorici/satori-plugin-grafana).
 
 ## [Notifications](notifications.md)
 
-We will notify you according to your preferences. We support a variety of communication methods:
+We offer a flexible notification system to keep your team updated about the satatus of your projects. We support a variety of communication methods:
 
 - Slack
 - Discord
@@ -45,11 +45,12 @@ We will notify you according to your preferences. We support a variety of commun
 - Telegram
 - Github Issues
 
-You can define these notifications within your [Team settings](https://www.satori-ci.com/team-settings/)
+You can define these notifications within your [dashboard settings](https://satori.ci/dashboard/) and set notification preferences in your project’s satori.yml file. Specify the conditions under which you want to be notified, whether on a failure or a success.
 
-## Reports
+## [Reports](execution-data.md) 
 
-We process the *output* to produce *reports* based on the *files* that were generated. We can also let you know about the difference between consecutive reports to identify whenever you are fixing -or introducing new- bugs. You can access your reports using on the [reports section of the Web](https://www.satori-ci.com/reports/) or with the CLI: `satori reports`.
+We process the *output* to generate *reports* based on the *files* that were produced. To help you track changes over time, we can highlight differences between consecutive reports. This feature is useful for identifying whether you are fixing existing bugs or introducing new ones.
+You can access your reports using on the [reports section of the Web](https://www.satori-ci/reports/) or with the CLI: `satori reports`.
 
 ## Support
 

--- a/satori_help/docs/modes/ci/gitlab.md
+++ b/satori_help/docs/modes/ci/gitlab.md
@@ -1,16 +1,22 @@
 # Gitlab CI/CD
 
-These are the steps to configure Gitlab to upload your project to Satori using your token.
+To integrate Satori with GitLab, follow these steps. This integration enables automated testing during your CI/CD pipeline, ensuring that tests are executed at each integration point
 
-**1) Log in Gitlab**
+1. **Log in to GitLab**  
 
-**2) Select your project**
+2. **Select your project**  
+   From your dashboard, choose the project you want to configure for Satori.
 
-**3) Click on Build -> Pipeline editor**
+3. **Navigate to Pipeline editor**  
+   Go to the project's sidebar and select **Build** > **Pipeline editor**. This is where you’ll configure your GitLab pipeline to communicate with Satori using your project token.
 
 ![Pipeline editor](img/gitlab_1.png)
 
-**4) Define the following script to install satori, configure its token and upload the code**
+4. **Define the pipeline script**  
+   In the **Pipeline editor**, create a script that will:
+   - Install Satori-CI.
+   - Configure the Satori token for authentication.
+   - Upload your project’s code to Satori for testing.
 
 ```yml
 image: python:latest
@@ -23,24 +29,26 @@ SatoriCI:
   script:
     - pip3 install satori-ci
     - satori config token $SATORI_TOKEN
-    - satori upload ./ --sync
+    - satori run ./ --sync
 ```
 
 ![Script](img/gitlab_2.png)
 
-Click on **Commit changes**
+After defining the script, click **Commit changes** to save the configuration.
 
-5) **Go to Settings -> CI/CD**
+5. **Add the Satori token in CI/CD settings**  
+  - Navigate to **Settings** > **CI/CD** in your project.
 
 ![Script](img/gitlab_3.png)
 
-6) **Expand the `Variables` and click on Add variable**
-
-Define the `SATORI_TOKEN` value:
-
-- **Key**: `SATORI_TOKEN`
-- **Value**: `<token>`
-
+6. Expand the **Variables** section and click **Add variable**.
+For the secret value, paste your Team API Token, which you can find it going to you [Dashboard](https://satori.ci/dashboard), select your team, click on Settings and copy your Team API token.
+   - Set the following variable to securely store your Satori token:
+     - **Key**: `SATORI_TOKEN`
+     - **Value**: `<token>` (replace `<token>` with your actual Satori token).
+       
 ![Script](img/gitlab_4.png)
 
-Click on **Add Variable** and you are set.
+7. Click **Add Variable** to complete the process.
+
+Your project is now configured to communicate with Satori, and automated tests with your playbook configured in your project, will run on every pipeline execution.


### PR DESCRIPTION
README:
adjustments were made to the README to clarify the use of rate instead of cron in the monitors section. Texts were revised, and broken links that redirected to .com were corrected. 

GITLAB: 
Adjustments were made to the GitLab page, where corrections were added, and the text was refined.
@fearcito 